### PR TITLE
Remove env.json symlink

### DIFF
--- a/devdata/env.json
+++ b/devdata/env.json
@@ -1,5 +1,0 @@
-{
-  "RC_WORKITEM_ADAPTER": "FileAdapter",
-  "RC_WORKITEM_INPUT_PATH": "devdata/work-items-in/test-input-for-producer/work-items.json",
-  "RC_WORKITEM_OUTPUT_PATH": "devdata/work-items-out/last-run/work-items.json"
-}

--- a/devdata/env.json
+++ b/devdata/env.json
@@ -1,1 +1,5 @@
-env-for-producer.json
+{
+  "RC_WORKITEM_ADAPTER": "FileAdapter",
+  "RC_WORKITEM_INPUT_PATH": "devdata/work-items-in/test-input-for-producer/work-items.json",
+  "RC_WORKITEM_OUTPUT_PATH": "devdata/work-items-out/last-run/work-items.json"
+}


### PR DESCRIPTION
I added two env.jsons (for producer and consumer), and then I symlinked the default to point at producer, but on a second thought that probably is not Windows (or rcc template) compatible.

It seems that in VSCode it works just fine without env.json, now that the mock data is packaged correctly. We can leave in the two example env.jsons for manual users, but maybe it shouldn't have this default at all.